### PR TITLE
add ACS#createOperatorAddSubscription()

### DIFF
--- a/rxt4a/src/main/java/com/cookpad/android/rxt4a/subscriptions/AndroidCompositeSubscription.java
+++ b/rxt4a/src/main/java/com/cookpad/android/rxt4a/subscriptions/AndroidCompositeSubscription.java
@@ -1,5 +1,7 @@
 package com.cookpad.android.rxt4a.subscriptions;
 
+import com.cookpad.android.rxt4a.operators.OperatorAddToCompositeSubscription;
+
 import android.support.annotation.NonNull;
 
 import rx.Subscription;
@@ -27,5 +29,9 @@ public class AndroidCompositeSubscription {
             compositeSubscription.unsubscribe();
             compositeSubscription = null;
         }
+    }
+
+    public <T> OperatorAddToCompositeSubscription<T> createOperatorAddSubscription() {
+        return new OperatorAddToCompositeSubscription<>(this);
     }
 }

--- a/rxt4a/src/test/java/com/cookpad/android/rxt4a/OperatorAddToCompositeSubscriptionTest.java
+++ b/rxt4a/src/test/java/com/cookpad/android/rxt4a/OperatorAddToCompositeSubscriptionTest.java
@@ -35,4 +35,22 @@ public class OperatorAddToCompositeSubscriptionTest {
         ts.awaitTerminalEvent(10, TimeUnit.MILLISECONDS);
         ts.assertNoTerminalEvent();
     }
+
+    @Test
+    public void testCreateOperator() throws Exception {
+        AndroidCompositeSubscription s = new AndroidCompositeSubscription();
+
+        TestSubscriber<String> ts = new TestSubscriber<>();
+
+        Observable.just("foo")
+                .lift(s.<String>createOperatorAddSubscription())
+                .delay(5, TimeUnit.MILLISECONDS)
+                .subscribe(ts);
+
+        s.unsubscribe();
+
+        ts.awaitTerminalEvent(10, TimeUnit.MILLISECONDS);
+        ts.assertNoTerminalEvent();
+    }
+
 }


### PR DESCRIPTION
cc @sys1yagi 

Note that the type parameter in `s.<String>createOperatorAddSubscription())` (i.e. `<String>`) is not completed by Android Studio, which is a little confusing.
