### PR TITLE
add AndroidSchedulers.serial() and .parallel()

### DIFF
--- a/rxt4a/src/main/java/com/cookpad/android/rxt4a/schedulers/AndroidSchedulers.java
+++ b/rxt4a/src/main/java/com/cookpad/android/rxt4a/schedulers/AndroidSchedulers.java
@@ -1,10 +1,12 @@
 package com.cookpad.android.rxt4a.schedulers;
 
+import android.os.AsyncTask;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.NonNull;
 
 import rx.Scheduler;
+import rx.schedulers.Schedulers;
 
 /**
  * Set of Android-specific schedulers
@@ -33,5 +35,23 @@ public class AndroidSchedulers {
      */
     public static HandlerScheduler from(@NonNull Handler handler) {
         return new HandlerScheduler(handler);
+    }
+
+    /**
+     * A background scheduler with {@link AsyncTask#SERIAL_EXECUTOR}.
+     *
+     * @return A scheduler which executes tasks in serial
+     */
+    public static Scheduler serial() {
+        return Schedulers.from(AsyncTask.SERIAL_EXECUTOR);
+    }
+
+    /**
+     * A background scheduler with {@link AsyncTask#THREAD_POOL_EXECUTOR}
+     *
+     * @return A scheduler which executes tasks in parallel
+     */
+    public static Scheduler parallel() {
+        return Schedulers.from(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 }

--- a/rxt4a/src/test/java/com/cookpad/android/rxt4a/AndroidSchedulersTest.java
+++ b/rxt4a/src/test/java/com/cookpad/android/rxt4a/AndroidSchedulersTest.java
@@ -11,6 +11,8 @@ import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 
+import rx.Scheduler;
+
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 
@@ -28,5 +30,15 @@ public class AndroidSchedulersTest {
     public void testCreateHandlerScheduler() throws Exception {
         Handler handler = new Handler();
         assertThat(AndroidSchedulers.from(handler).getHandler(), is(handler));
+    }
+
+    @Test
+    public void testSerialScheduler() throws Exception {
+        assertThat(AndroidSchedulers.serial(), is(instanceOf(Scheduler.class)));
+    }
+
+    @Test
+    public void testParallelScheduler() throws Exception {
+        assertThat(AndroidSchedulers.parallel(), is(instanceOf(Scheduler.class)));
     }
 }


### PR DESCRIPTION
As interfaces to AsyncTask executors `AsyncTask.SERIAL_EXECUTOR` and `AsyncTask.THREAD_POOL_EXECUTOR`.

These schedulers might not use extra resources other than what Android Framework provides.
